### PR TITLE
Allow to use a nonstandard port

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -49,9 +49,11 @@ Clone this repo:
     Resolving deltas: 100% (51/51), done.
     $ cd beersample-java
 
-Run the application using jetty container:
+Run the application using jetty container. The -D option is optional
+and may be used to connect to a cluster running elsewhere (or a
+nonstandard port):
 
-    $ mvn jetty:run
+    $ mvn [-D com.couchbase.beersample.cluster=http://127.0.0.1:8091/pools] jetty:run
     .... snip ....
     Dec 17, 2012 1:50:16 PM com.couchbase.beersample.ConnectionManager contextInitialized
     INFO: Connecting to Couchbase Cluster

--- a/src/main/java/com/couchbase/beersample/ConnectionManager.java
+++ b/src/main/java/com/couchbase/beersample/ConnectionManager.java
@@ -60,7 +60,7 @@ public class ConnectionManager implements ServletContextListener {
   public void contextInitialized(ServletContextEvent sce) {
     logger.log(Level.INFO, "Connecting to Couchbase Cluster");
     ArrayList<URI> nodes = new ArrayList<URI>();
-    nodes.add(URI.create("http://127.0.0.1:8091/pools"));
+    nodes.add(URI.create(System.getProperty("com.couchbase.beersample.cluster", "http://127.0.0.1:8091/pools")));
     try {
       client = new CouchbaseClient(nodes, "beer-sample", "");
     } catch (IOException ex) {


### PR DESCRIPTION
This makes it easier to use the beersample to connect to a cluster started with cluster_run
